### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # CHANGELOG.md for https://GitHub.com/Smiley-McSmiles/llaman
 
+# LLaMan v0.2.0
+## Changes
+- Backup now completely backups /opt/open-webui and Ollama for easy import on another machine.
+ - Meaning backups will now be rather large!
+
+## Fixes
+- Fixed language in setup.sh
+- Fixed some langauge in llaman
+
+## Additions
+- Added OpendAI-Speech integration
+ - _Default port is `8000`_
+- Added `llaman -cps` (**C**hange **P**ort **S**peech)
+ - _Presents a prompt to enter a new port for OpendAI-Speech_
+- `sudo ./setup.sh` now has a `-I` option. Supply path to **I**mport a llaman.tar backup.
+ - _example:_ `sudo ./setup.sh -I /path/to/llaman-backup.tar`
+
 # LLaMan v0.1.9
 ## Fixes
 - Removed dead line in the setup script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # LLaMan v0.2.0
 ## Changes
 - Backup now completely backups /opt/open-webui and Ollama for easy import on another machine.
- - Meaning backups will now be rather large!
+  - Meaning backups will now be rather large!
 
 ## Fixes
 - Fixed language in setup.sh
@@ -11,11 +11,11 @@
 
 ## Additions
 - Added OpendAI-Speech integration
- - _Default port is `8000`_
+  - _Default port is `8000`_
 - Added `llaman -cps` (**C**hange **P**ort **S**peech)
- - _Presents a prompt to enter a new port for OpendAI-Speech_
+  - _Presents a prompt to enter a new port for OpendAI-Speech_
 - `sudo ./setup.sh` now has a `-I` option. Supply path to **I**mport a llaman.tar backup.
- - _example:_ `sudo ./setup.sh -I /path/to/llaman-backup.tar`
+  - _example:_ `sudo ./setup.sh -I /path/to/llaman-backup.tar`
 
 # LLaMan v0.1.9
 ## Fixes

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd ~/
 * **Backup** - Input a directroy to output a backup archive
 * **Backup Utility** - Start the Backup Utility to set up automatic backups
 * **Import** - Import a .tar file to pick up where you left off on another system
- - _Use `sudo ./setup.sh /path/to/llaman-backup.tar` to import/restore a backup_
+  - _Use `sudo ./setup.sh /path/to/llaman-backup.tar` to import/restore a backup_
 * **Get Version** - Get the current installed version of LLaMan, Ollama, and Open-WebUI
 * **View Logs** - Select from a list of logs to view
 * **Uninstall** - Uninstalls LLaMan, Ollama, Open-WebUI, and Opend-AI-Speech completely

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-> LLaMan v0.1.9 - An Ollama and Open-WebUI manager written in BASH
+> LLaMan v0.2.0 - An Ollama and Open-WebUI manager written in BASH
 
-> Tested on Fedora 40
+> Tested on Fedora 40/41 | Ubuntu 24.04
 
 > Should work on Any Debian, Arch, or RHEL Based Distribution **with SystemD**
 
 # Description
 
-LLaMan is a lightweight BASH CLI (Command Line Interface) tool for installing and managing Ollama and Open-WebUI.
+LLaMan is a lightweight BASH CLI (Command Line Interface) tool for installing and managing Ollama, Open-WebUI, and OpendAI-Speech.
 
 # Getting Started
 
@@ -15,55 +15,58 @@ git clone https://github.com/Smiley-McSmiles/llaman
 cd llaman
 chmod ug+x setup.sh
 sudo ./setup.sh
+# sudo ./setup.sh -I /path/to/llaman-backup.tar
 cd ~/
 ```
 
 # Features
 
-* **Setup** - Sets up the initial install.
-* **Update** - Downloads and updates to the latest Ollama or Open-WebUI version
-* **Disable** - Disable ollama.service and open-webui.service
-* **Enable** - Enable ollama.service and open-webui.service
-* **Start** - Start ollama.service and open-webui.service
-* **Stop** - Stop ollama.service and open-webui.service
-* **Restart** - Restart ollama.service and open-webui.service
-* **Status** - Get status of ollama.service and open-webui.service
+* **Setup** - Install Ollama, Open-WebUI, and OpendAI-Speech at once
+* **Update** - Downloads and updates to the latest Ollama, Open-WebUI, OpendAI-Speech versions
+* **Disable** - Disable Ollama, Open-WebUI, and Opend-Speech
+* **Enable** - Enable Ollama, Open-WebUI, and Opend-Speech
+* **Start** - Start Ollama, Open-WebUI, and Opend-Speech
+* **Stop** - Stop Ollama, Open-WebUI, and Opend-Speech
+* **Restart** - Restart Ollama, Open-WebUI, and Opend-Speech
+* **Status** - Get status of Ollama, Open-WebUI, and Opend-Speech
 * **Download** - Download a .gguf file from Hugging Face via URL
 * **Remove** - Remove a model from Ollama
 * **Remove GGUF** - Remove a downloaded .gguf model
 * **Install** - Install a downloaded .gguf model
-* **Change Port** - Change the default port for Open-WebUI
+* **Change Port** - Change the default port for Open-WebUI or OpendAI-Speech
 * **Backup** - Input a directroy to output a backup archive
 * **Backup Utility** - Start the Backup Utility to set up automatic backups
 * **Import** - Import a .tar file to pick up where you left off on another system
+ - _Use `sudo ./setup.sh /path/to/llaman-backup.tar` to import/restore a backup_
 * **Get Version** - Get the current installed version of LLaMan, Ollama, and Open-WebUI
 * **View Logs** - Select from a list of logs to view
-* **Uninstall** - Uninstalls LLaMan, Ollama, and Open-WebUI completely
+* **Uninstall** - Uninstalls LLaMan, Ollama, Open-WebUI, and Opend-AI-Speech completely
 
 # Usage
 ```
 llaman [PARAMETER]
 
 PARAMETERS:
--b,    --backup           Backup Open-WebUI users and settings
--bu,   --backup-utility   Start the backup utility
--i,    --import           Import Open-WebUI archive
--e,    --enable           Enable Ollama and Open-WebUI
--d,    --disable          Disable Ollama and Open-WebUI
--s,    --start            Start Ollama and Open-WebUI
--S,    --stop             Stop Ollama and Open-WebUI
--r,    --restart          Restart Ollama and Open-WebUI
--t,    --status           Get status of ollama.service and open-webui.service.
--I,    --install          Install a downloaded .gguf model
--R,    --remove           Remove model from Ollama
--rg,   --remove-gguf      Remove downloaded .gguf model
--D,    --download         Download .gguf file from https://huggingface.co
--u,    --update           Update Ollama and Open-Webui
--cp,    --change-port      Change the Open-WebUI port
--v,    --version          Get LLaMan, Ollama, and Open-Webui version
--vl,   --view-logs        View LLaMan logs
--h,    --help             Display this help menu
--X,    --uninstall        Uninstall LLaMan, Ollama, and Open-Webui
+-b,    --backup             Backup Open-WebUI users and settings
+-bu,   --backup-utility     Start the backup utility
+-i,    --import             Import Open-WebUI archive
+-e,    --enable             Enable Ollama and Open-WebUI
+-d,    --disable            Disable Ollama and Open-WebUI
+-s,    --start              Start Ollama and Open-WebUI
+-S,    --stop               Stop Ollama and Open-WebUI
+-r,    --restart            Restart Ollama and Open-WebUI
+-t,    --status             Get status of ollama.service and open-webui.service.
+-I,    --install            Install a downloaded .gguf model
+-R,    --remove             Remove model from Ollama
+-rg,   --remove-gguf        Remove downloaded .gguf model
+-D,    --download           Download .gguf file from https://huggingface.co
+-u,    --update             Update Ollama and Open-Webui
+-cp,   --change-port        Change the Open-WebUI port
+-cps,  --change-port-speech ChangeSpeechPort
+-v,    --version            Get LLaMan, Ollama, and Open-Webui version
+-vl,   --view-logs          View LLaMan logs
+-h,    --help               Display this help menu
+-X,    --uninstall          Uninstall LLaMan, Ollama, and Open-Webui
 Example: sudo llaman -e
 ```
 

--- a/configs/modelfiles/DEFAULT
+++ b/configs/modelfiles/DEFAULT
@@ -1,1 +1,1 @@
-FROM /shared/llms/Pocket-Tiger-Gemma-2B-v1d-Q6_K.gguf
+FROM /shared/llms/josiefied-qwen2.5-14b-instruct-abliterated-v4.Q4_0.gguf

--- a/configs/modelfiles/chatml
+++ b/configs/modelfiles/chatml
@@ -1,4 +1,4 @@
-FROM /shared/llms/MN-12B-Celeste-V1.9.i1-Q4_0.gguf
+FROM /shared/llms/UnslopNemo-12B-v4.1.i1-Q4_K_M.gguf
 TEMPLATE """
 {{ if .System }}<|im_start|>system
 {{ .System }}<|im_end|>

--- a/configs/modelfiles/mistral-nemo
+++ b/configs/modelfiles/mistral-nemo
@@ -1,4 +1,4 @@
-FROM /shared/llms/Mistral-Nemo-Instruct-12B-iMat-Q4_K_M.gguf
+FROM /shared/llms/Mistral-Small-22B-ArliAI-RPMax-v1.1.i1-Q4_K_M.gguf
 TEMPLATE """
 {{- range $i, $_ := .Messages }}
 {{- if eq .Role "user" }}

--- a/configs/modelfiles/nemotron-mini
+++ b/configs/modelfiles/nemotron-mini
@@ -1,0 +1,39 @@
+FROM /shared/llms/UnslopNemo-12B-v4.1.i1-Q4_K_M.gguf
+TEMPLATE """
+{{- if (or .Tools .System) }}<extra_id_0>System
+{{ if .System }}{{ .System }}
+
+
+{{ end }}
+{{- if .Tools }}
+{{- range .Tools }}<tool> {{ . }} </tool>{{ end }}
+
+
+{{ end }}
+{{- end }}
+{{- range $i, $m := .Messages }}
+{{- $last := eq (len (slice $.Messages $i)) 1 -}}
+{{- if eq .Role "user" }}<extra_id_1>User
+{{ .Content }}
+{{- if $last }}
+<extra_id_1>Assistant
+{{- end }}
+{{ else if eq .Role "tool" }}<extra_id_1>Tool
+{{ .Content }}
+{{- if $last }}
+<extra_id_1>Assistant
+{{- end }}
+{{ else if eq .Role "assistant" }}<extra_id_1>Assistant
+{{- if .ToolCalls }}
+{{ range .ToolCalls }}<toolcall> {"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}} </toolcall> {{ end }}
+{{ else }}
+{{ .Content }}
+{{- if not $last }}
+{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+"""
+PARAMETER stop "</s>"
+PARAMETER stop "USER:"
+PARAMETER stop "ASSISTANT:"

--- a/configs/modelfiles/qwen2_5
+++ b/configs/modelfiles/qwen2_5
@@ -1,0 +1,56 @@
+FROM /shared/llms/josiefied-qwen2.5-14b-instruct-abliterated-v4.Q4_0.gguf
+TEMPLATE """
+{{- if .Messages }}
+{{- if or .System .Tools }}<|im_start|>system
+{{- if .System }}
+{{ .System }}
+{{- end }}
+{{- if .Tools }}
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{{- range .Tools }}
+{"type": "function", "function": {{ .Function }}}
+{{- end }}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+<tool_call>
+{"name": <function-name>, "arguments": <args-json-object>}
+</tool_call>
+{{- end }}<|im_end|>
+{{ end }}
+{{- range $i, $_ := .Messages }}
+{{- $last := eq (len (slice $.Messages $i)) 1 -}}
+{{- if eq .Role "user" }}<|im_start|>user
+{{ .Content }}<|im_end|>
+{{ else if eq .Role "assistant" }}<|im_start|>assistant
+{{ if .Content }}{{ .Content }}
+{{- else if .ToolCalls }}<tool_call>
+{{ range .ToolCalls }}{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}
+{{ end }}</tool_call>
+{{- end }}{{ if not $last }}<|im_end|>
+{{ end }}
+{{- else if eq .Role "tool" }}<|im_start|>user
+<tool_response>
+{{ .Content }}
+</tool_response><|im_end|>
+{{ end }}
+{{- if and (ne .Role "assistant") $last }}<|im_start|>assistant
+{{ end }}
+{{- end }}
+{{- else }}
+{{- if .System }}<|im_start|>system
+{{ .System }}<|im_end|>
+{{ end }}{{ if .Prompt }}<|im_start|>user
+{{ .Prompt }}<|im_end|>
+{{ end }}<|im_start|>assistant
+{{ end }}{{ .Response }}{{ if .Response }}<|im_end|>{{ end }}
+"""
+PARAMETER stop "</s>"
+PARAMETER stop "USER:"
+PARAMETER stop "ASSISTANT:"

--- a/configs/opendai.service
+++ b/configs/opendai.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Opendai
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/open-webui/opendai-speech
+ExecStart=/opt/open-webui/opendai-speech/start-tts.sh
+RestartForceExitStatus=3
+User=open-webui
+
+[Install]
+WantedBy=multi-user.target

--- a/llaman.1
+++ b/llaman.1
@@ -7,7 +7,7 @@
 .B LLaMan - An Ollama and Open-WebUI manager written in BASH
 
 .SH VERSION
-.B LLaMan v0.1.9
+.B LLaMan v0.2.0
 
 .SH SYNOPSIS
 .B llaman
@@ -22,43 +22,45 @@ is a lightweight BASH CLI (Command Line Interface) tool for installing and manag
 .TP
 .SS COMMANDS
 .TP
-.B -b, --backup                 Create llaman-backup.tar archive.
+.B -b,    --backup               Create llaman-backup.tar archive.
 .TP
-.B -bu, --backup-utility        Launch the automatic Backup Utility.
+.B -bu,   --backup-utility       Launch the automatic Backup Utility.
 .TP
-.B -i, --import                 Launch the import backup utility.
+.B -i,    --import               Launch the import backup utility.
 .TP
-.B -e, --enable                 Enable Ollama and Open-WebUI on System Start.
+.B -e,    --enable               Enable Ollama and Open-WebUI on System Start.
 .TP
-.B -d, --disable                Disable Ollama and Open-WebUI on System Start.
+.B -d,    --disable              Disable Ollama and Open-WebUI on System Start.
 .TP
-.B -s, --start                  Start Ollama and Open-WebUI.
+.B -s,    --start                Start Ollama and Open-WebUI.
 .TP
-.B -S, --stop                   Stop Ollama and Open-WebUI.
+.B -S,    --stop                 Stop Ollama and Open-WebUI.
 .TP
-.B -r, --restart                Restart Ollama and Open-WebUI.
+.B -r,    --restart              Restart Ollama and Open-WebUI.
 .TP
-.B -t, --status                 Status of Ollama and Open-WebUI.
+.B -t,    --status               Status of Ollama and Open-WebUI.
 .TP
-.B -I, --install                Install a downloaded .gguf model.
+.B -I,    --install              Install a downloaded .gguf model.
 .TP
-.B -R, --remove                 Remove a model from Ollama
+.B -R,    --remove               Remove a model from Ollama
 .TP
-.B -rg,   --remove-gguf         Remove downloaded .gguf model
+.B -rg,   --remove-gguf          Remove downloaded .gguf model
 .TP
-.B -D, --download               Download a .gguf file from https://huggingface.co
+.B -D,    --download             Download a .gguf file from https://huggingface.co
 .TP
-.B -u, --update                 Update/check for updates for LLaMan, Ollama, and Open-WebUI
+.B -u,    --update               Update/check for updates for LLaMan, Ollama, and Open-WebUI
 .TP
-.B -cp, --change-port            Change the Open-WebUI port
+.B -cp,   --change-port          Change the Open-WebUI port
 .TP
-.B -v, --version                Get the current installed version of LLaMan.
+.B -cps,  --change-port-speech   ChangeSpeechPort
 .TP
-.B -vl, --view-log              Choose from a list of logs to view.
+.B -v,    --version              Get the current installed version of LLaMan.
 .TP
-.B -h, --help                   Print this Help.
+.B -vl,   --view-log             Choose from a list of logs to view.
 .TP
-.B -X, --uninstall              Uninstall LLaMan, Ollama and Open-WebUI Completely.
+.B -h,    --help                 Print this Help.
+.TP
+.B -X,    --uninstall            Uninstall LLaMan, Ollama and Open-WebUI Completely.
 
 .SH EXAMPLE
 .TP
@@ -67,7 +69,7 @@ is a lightweight BASH CLI (Command Line Interface) tool for installing and manag
 .SH FILES
 .TP
 .I
-/opt/open-webui
+/opt/open-webui/config/llaman.conf
 .TP
 .I
 /usr/bin/llaman

--- a/scripts/llaman
+++ b/scripts/llaman
@@ -1,6 +1,6 @@
 #!/bin/bash
 source /usr/bin/llaman-functions
-llamanVersion=0.1.9
+llamanVersion=0.2.0
 configFile=/opt/open-webui/config/llaman.conf
 
 help="
@@ -9,25 +9,26 @@ LLaMan $llamanVersion
 llaman [PARAMETER]
 
 PARAMETERS:
--b,    --backup           Backup Open-WebUI users and settings
--bu,   --backup-utility   Start the backup utility
--i,    --import           Import Open-WebUI archive
--e,    --enable           Enable Ollama and Open-WebUI
--d,    --disable          Disable Ollama and Open-WebUI
--s,    --start            Start Ollama and Open-WebUI
--S,    --stop             Stop Ollama and Open-WebUI
--r,    --restart          Restart Ollama and Open-WebUI
--t,    --status           Get status of ollama.service and open-webui.service.
--I,    --install          Install a downloaded .gguf model
--R,    --remove           Remove model from Ollama
--rg,   --remove-gguf      Remove downloaded .gguf model
--D,    --download         Download .gguf file from https://huggingface.co
--u,    --update           Update Ollama and Open-Webui
--cp,    --change-port      Change the Open-WebUI port
--v,    --version          Get LLaMan, Ollama, and Open-Webui version
--vl,   --view-logs        View LLaMan logs
--h,    --help             Display this help menu
--X,    --uninstall        Uninstall LLaMan, Ollama, and Open-Webui
+-b,    --backup             Backup Open-WebUI users and settings
+-bu,   --backup-utility     Start the backup utility
+-i,    --import             Import Open-WebUI archive
+-e,    --enable             Enable Ollama and Open-WebUI
+-d,    --disable            Disable Ollama and Open-WebUI
+-s,    --start              Start Ollama and Open-WebUI
+-S,    --stop               Stop Ollama and Open-WebUI
+-r,    --restart            Restart Ollama and Open-WebUI
+-t,    --status             Get status of ollama.service and open-webui.service.
+-I,    --install            Install a downloaded .gguf model
+-R,    --remove             Remove model from Ollama
+-rg,   --remove-gguf        Remove downloaded .gguf model
+-D,    --download           Download .gguf file from https://huggingface.co
+-u,    --update             Update Ollama and Open-Webui
+-cp,   --change-port        Change the Open-WebUI port
+-cps,  --change-port-speech ChangeSpeechPort
+-v,    --version            Get LLaMan, Ollama, and Open-Webui version
+-vl,   --view-logs          View LLaMan logs
+-h,    --help               Display this help menu
+-X,    --uninstall          Uninstall LLaMan, Ollama, and Open-Webui
 Example: sudo llaman -e
 "
 
@@ -42,19 +43,8 @@ Backup()
 	_fileName="llaman-backup-$_date.tar"
 	_tarPath=$backupDirectory/$_fileName
 	
-	if [[ ! -d /opt/open-webui/backup ]]; then
-		mkdir /opt/open-webui/backup
-	fi
-	
-	cp -rf $defaultDir/open-webui/backend/data $defaultDir/backup/
-	cp -rf $defaultDir/config $defaultDir/backup/
-	cp -rf $defaultDir/log $defaultDir/backup/
-	cp -rf $defaultDir/miniconda3 $defaultDir/backup/
-	cp -rf $serviceDirectory/llaman-backup.timer $defaultDir/backup/
-	cp -f $defaultDir/start.sh $defaultDir/backup/
-	time tar cf "$_tarPath" /opt/open-webui/backup
-	
-	rm -rf $defaultDir/backup
+	ollamaDirs="$(whereis ollama | cut -d ' ' -f 2-)"
+	time tar cf "$_tarPath" $defaultDir /usr/bin/llaman /usr/bin/llaman-functions $ollamaDirs /etc/systemd/system/ollama.service $serviceDirectory/llaman-backup.service $serviceDirectory/llaman-backup.timer $serviceDirectory/open-webui.service
 	
 	USER1=$(stat -c '%U' "$backupDirectory")
 	chown -f $USER1:$USER1 "$_tarPath"
@@ -231,20 +221,14 @@ Import() {
 
 	source $configFile
 	
+	echo "> WARNING!: This procedure will completely erase $defaultDir"
 	importTarDir=$backupDirectory
 	PresentList "$importTarDir" "Please enter the number corresponding to the .tar you want to select." "llaman-backup-"
 	importTar=$importTarDir/$presentListResult
 	
 	llaman -S
+	rm -rf $defaultDir
 	tar xf $importTar -C /
-	cp -rf $defaultDir/backup/data $defaultDir/open-webui/backend/ 
-	cp -rf $defaultDir/backup/config $defaultDir/
-	cp -rf $defaultDir/backup/log $defaultDir/
-	cp -rf $defaultDir/backup/miniconda3 $defaultDir/
-	cp -rf $defaultDir/backup/start.sh $defaultDir/
-	cp -rf $defaultDir/backup/llaman-backup.timer $serviceDirectory/
-	
-	rm -rf /$defaultDir/backup
 
 	chown -Rf $defaultUser:$defaultUser $defaultDir
 	chmod -Rf 770 $defaultDir
@@ -355,14 +339,24 @@ DownloadModel()
 
 ChangePort()
 {
-	SetVar httpPort $httpPort "$configFile" bash int
-	PromptUser num "Enter a valid port" 1001 9999 "$minNumber-$maxNumber"
+	PromptUser num "Enter a valid port" 1024 65535 "$minNumber-$maxNumber"
 	httpPort=$promptResult
 	echo "> Changing Open-WebUI port to $httpPort"
-
+	SetVar httpPort $httpPort "$configFile" bash int
 	sed -ri "s|-8080|-$httpPort|g" $defaultDir/open-webui/backend/start.sh
 	Log "SETUP | SetVar httpPort=$httpPort" $logFile
 	Control restart
+}
+
+ChangePortSpeech()
+{
+	PromptUser num "Enter a valid port" 1024 65535 "$minNumber-$maxNumber"
+	opendaiPort=$promptResult
+	echo "> Changing Open-WebUI port to $opendaiPort"
+	SetVar httpPort $opendaiPort "$configFile" bash int
+	sed -ri "s|-8080|-$opendaiPort|g" $defaultDir/open-webui/backend/start.sh
+	Log "SETUP | SetVar httpPort=$opendaiPort" $logFile
+	systemctl restart opendai
 }
 
 UpdateWeb()
@@ -372,36 +366,129 @@ UpdateWeb()
 	fi
 
 	source $configFile
-
-	cd $defaultDir
-	
-	if [[ -d open-webui-backup ]]; then
-		rm -rf open-webui-backup
+	systemctl stop open-webui
+	if [[ -d $defaultDir/open-webui-backup ]]; then
+		rm -rf $defaultDir/open-webui-backup
 	fi
 	
-	mv open-webui open-webui-backup
-	git clone https://github.com/open-webui/open-webui.git
-	cd open-webui/
+	mv $defaultDir/open-webui $defaultDir/open-webui-backup
+	git clone https://github.com/open-webui/open-webui.git $defaultDir/
+	cp -RPp $defaultDir/open-webui/.env.example $defaultDir/open-webui/.env
 
-	cp -RPp .env.example .env
-
+	cd $defaultDir/open-webui/
 	npm i
 	npm run build
+	cd -
 
-	cd backend/
-	
 	# Move data from previous install
-	cp -rfv ../../open-webui-backup/backend/data ./
+	cp -rfv $defaultDir/open-webui/open-webui-backup/backend/data $defaultDir/open-webui/backend/
 
-	sed -ri "s|exec uvicorn|python -m uvicorn|g" start.sh
-	sed -i "/^WEBUI_SECRET_KEY=/ s/$/ | tee \/opt\/open-webui\/log\/open-webui.log/" start.sh
+	sed -ri "s|exec uvicorn|python -m uvicorn|g" $defaultDir/open-webui/backend/start.sh
+	sed -i "/^WEBUI_SECRET_KEY=/ s/$/ | tee \/opt\/open-webui\/log\/open-webui.log/" $defaultDir/open-webui/backend/start.sh
 	chown -Rf $defaultUser:$defaultUser $defaultDir
 	chmod -Rf 770 $defaultDir
-	sudo -u $defaultUser bash -c "\
-	$defaultDir/config/conda/open-webui/bin/pip install -r $defaultDir/open-webui/backend/requirements.txt"
-	Control restart
-	
+	sudo -u $defaultUser bash -c "
+		source $defaultDir/miniconda3/etc/profile.d/conda.sh
+		conda init --all"
+	sudo -u $defaultUser bash -c "
+		source $defaultDir/miniconda3/etc/profile.d/conda.sh
+		conda activate $defaultDir/config/conda/open-webui
+		pip install -r $defaultDir/open-webui/backend/requirements.txt
+		conda deactivate"
+	systemctl start open-webui
 }
+
+#UpdateWeb()
+#{
+#	if ! HasSudo; then
+#		exit
+#	fi
+#
+#	source $configFile
+#	systemctl stop open-webui
+#	if [[ -d $defaultDir/open-webui-backup ]]; then
+#		rm -rf $defaultDir/open-webui-backup
+#	fi
+#
+#	mv $defaultDir/open-webui $defaultDir/open-webui-backup
+#	git clone https://github.com/open-webui/open-webui.git $defaultDir/
+#	cp -RPp $defaultDir/open-webui/.env.example $defaultDir/open-webui/.env
+#
+#	cd $defaultDir/open-webui/
+#	npm i
+#	npm run build
+#	cd -
+#
+#	# Move data from previous install
+#	cp -rfv $defaultDir/open-webui/open-webui-backup/backend/data $defaultDir/open-webui/backend/
+#
+#	sed -ri "s|exec uvicorn|python -m uvicorn|g" $defaultDir/open-webui/backend/start.sh
+#	sed -i "/^WEBUI_SECRET_KEY=/ s/$/ | tee \/opt\/open-webui\/log\/open-webui.log/" $defaultDir/open-webui/backend/start.sh
+#	chown -Rf $defaultUser:$defaultUser $defaultDir
+#	chmod -Rf 770 $defaultDir
+#	$defaultDir/miniconda3/bin/activate $defaultDir/config/conda/open-webui
+#	$defaultDir/config/conda/open-webui/bin/pip install -r $defaultDir/open-webui/backend/requirements.txt
+#	$defaultDir/miniconda3/bin/deactivate
+#	systemctl start open-webui
+#}
+
+UpdateTTS(){
+	if ! HasSudo; then
+		exit
+	fi
+
+	pyVersion="3.11"
+	systemctl stop opendai
+	source $defaultDir/miniconda3/bin/activate
+	if [[ -d $defaultDir/opendai-speech-backup ]]; then
+		rm -rf $defaultDir/opendai-speech-backup
+		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
+	elif [[ -d $defaultDir/opendai-speech ]]; then
+		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
+	fi
+	chown -Rf $defaultUser:$defaultUser $defaultDir
+	sudo -u $defaultUser bash -c "git clone https://github.com/matatonic/openedai-speech $defaultDir/opendai-speech
+		cp $defaultDir/opendai-speech-backup/start-tts.sh $defaultDir/opendai-speech/
+		source $defaultDir/miniconda3/etc/profile.d/conda.sh
+		conda init --all"
+	sudo -u $defaultUser bash -c "
+		conda activate $defaultDir/config/conda/opendai
+		pip install -U -r $defaultDir/opendai-speech/requirements.txt
+		cp $defaultDir/opendai-speech/sample.env $defaultDir/opendai-speech/speech.env
+		cp $defaultDir/opendai-speech/say.py $defaultDir/opendai-speech/say.py.bak
+		sed -i 's/# export OPENAI_API_KEY=sk-11111111111/export OPENAI_API_KEY=sk-11111111111,/g' $defaultDir/opendai-speech/say.py
+		sed -i 's/api_key = os.environ.get(\"OPENAI_API_KEY\", \"sk-ip\"),/api_key = \"sk-11111111111\",/g' $defaultDir/opendai-speech/say.py
+		sed -i 's/\# export OPENAI_BASE_URL\=http\:\/\/localhost:8000\/v1/export OPENAI_BASE_URL\=http\:\/\/localhost:${opendaiPort}\/v1,/g' $defaultDir/opendai-speech/say.py
+		conda deactivate"
+	systemctl start opendai
+}
+
+#UpdateTTS(){
+#	if ! HasSudo; then
+#		exit
+#	fi
+#
+#	pyVersion="3.11"
+#	systemctl stop opendai
+#	source $defaultDir/miniconda3/bin/activate
+#	if [[ -d $defaultDir/opendai-speech-backup ]]; then
+#		rm -rf $defaultDir/opendai-speech-backup
+#		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
+#	elif [[ -d $defaultDir/opendai-speech ]]; then
+#		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
+#	fi
+#	git clone https://github.com/matatonic/openedai-speech $defaultDir/opendai-speech
+#	$defaultDir/miniconda3/bin/activate $defaultDir/config/conda/opendai
+#	$defaultDir/config/conda/opendai/bin/pip install -U -r $defaultDir/opendai-speech/requirements.txt
+#	cp $defaultDir/opendai-speech/sample.env $defaultDir/opendai-speech/speech.env
+#	cp $defaultDir/opendai-speech/say.py $defaultDir/opendai-speech/say.py.bak
+#	sed -i 's/# export OPENAI_API_KEY=sk-11111111111/export OPENAI_API_KEY=sk-11111111111,/g' $defaultDir/opendai-speech/say.py
+#	sed -i 's/api_key = os.environ.get("OPENAI_API_KEY", "sk-ip"),/api_key = "sk-11111111111",/g' $defaultDir/opendai-speech/say.py
+#	sed -i "s/\# export OPENAI_BASE_URL\=http\:\/\/localhost:8000\/v1/export OPENAI_BASE_URL\=http\:\/\/localhost:$opendaiPort\/v1,/g" $defaultDir/opendai-speech/say.py
+#	chown -Rf $defaultUser:$defaultUser $defaultDir
+#	$defaultDir/miniconda3/bin/deactivate
+#	systemctl start opendai
+#}
 
 Update()
 {
@@ -416,6 +503,8 @@ Update()
 	latestOllamaVersion=$(GetLatestOllamaVersion)
 	installedWebUIVersion=$(GetWebUIVersion)
 	latestWebUIVersion=$(GetLatestWebUIVersion)
+	installedOpendAIVersion=$(GetOpendAIVersion)
+	latestOpendAIVersion=$(getLatestOpendAIVersion)
 	
 	if [[ ! "$installedOllamaVersion" == "$latestOllamaVersion" ]]; then
 		curl -fsSL https://ollama.com/install.sh | sh
@@ -429,6 +518,13 @@ Update()
 		Log "UPDATE | Updated Open-WebUI to v$latestWebUIVersion" $logFile
 	else
 		echo "> The latest Open Web-UI version $latestWebUIVersion is already installed."
+	fi
+
+	if [[ ! "$installedOpendAIVersion" == "$latestOpendAIVersion" ]]; then
+		UpdateTTS
+		Log "UPDATE | Updated OpendAI-Speech to v$latestOpendAIVersion" $logFile
+	else
+		echo "> The latest Open Web-UI version $latestOpendAIVersion is already installed."
 	fi
 	
 	if [[ ! "$installedLlamanVersion" == "$latestLlamanVersion" ]]; then
@@ -451,9 +547,11 @@ GetVersions()
 
 	installedOllamaVersion=$(GetOllamaVersion)
 	installedWebUIVersion=$(GetWebUIVersion)
+	installedOpendAIVersion=$(GetOpendAIVersion)
 	echo "LLaMan v$llamanVersion"
 	echo "Ollama v$installedOllamaVersion"
 	echo "Open-WebUI v$installedWebUIVersion"
+	echo "OpendAI-Speech v$installedOpendAIVersion"
 }
 
 GetLatestLlamanVersion()
@@ -482,6 +580,16 @@ GetWebUIVersion()
 	echo $(head -n 15 $defaultDir/open-webui/CHANGELOG.md | grep -o "[0-9].[0-9]\.[0-9][0-9]")
 }
 
+GetOpendAIVersion(){
+	source $configFile
+	echo $(cat $defaultDir/opendai-speech/README.md | grep "Version.*[0-1]\." | head -n 1 | grep -o "[0-9]\.[0-9][0-9]\.[0-9]")
+}
+
+GetLatestOpendAIVersion()
+{
+	echo $(curl -fsSL https://github.com/matatonic/openedai-speech/releases/latest | grep '<title>' | grep -o "[0-9]\.[0-9][0-9]\.[0-9]")
+}
+
 Control()
 {
 	if ! HasSudo; then
@@ -491,16 +599,18 @@ Control()
 	source $configFile
 	
 	case "$1" in
-		start) systemctl start ollama open-webui
-         	Log "LLAMAN | Started Ollama and Open-webui" $logFile ;;
-		stop) systemctl stop ollama open-webui
-         	Log "LLAMAN | Stopped Ollama and Open-webui" $logFile ;;
-		enable) systemctl enable ollama open-webui
-         	Log "LLAMAN | Enabled Ollama and Open-webui" $logFile ;;
-		disable) systemctl disable ollama open-webui
-         	Log "LLAMAN | Disabled Ollama and Open-webui" $logFile ;;
-		restart) systemctl restart ollama open-webui
-         	Log "LLAMAN | Restarted Ollama and Open-webui" $logFile ;;
+		start) systemctl start ollama open-webui opendai
+			Log "LLAMAN | Started Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
+		stop) systemctl stop ollama open-webui opendai
+			Log "LLAMAN | Stopped Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
+		enable) systemctl enable ollama open-webui opendai
+			Log "LLAMAN | Enabled Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
+		disable) systemctl disable ollama open-webui opendai
+			Log "LLAMAN | Disabled Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
+		restart) systemctl restart ollama open-webui opendai
+			Log "LLAMAN | Restarted Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
+		status) systemctl status ollama open-webui opendai
+			Log "LLAMAN | Restarted Ollama, Open-webui, and OpendAI-Speech" $logFile ;;
 	esac
 }
 
@@ -511,21 +621,21 @@ Uninstall()
 	fi
 
 	source $configFile
-	if PromptUser yN "Are you sure you want to fully uninstall LLaman/Ollama/Open-webui?" 0 0 "y/N"; then
+	if PromptUser yN "Are you sure you want to fully uninstall LLaman/Ollama/Open-webui/OpendAI-Speech?" 0 0 "y/N"; then
 		llaman -d -S
 		userdel $defaultUser
 		userdel ollama
-		sleep 3
 		groupdel $defaultUser
 		groupdel ollama
-		sleep 2
-		rm -f $serviceLocation/open-webui.service
-		rm -f $serviceLocation/ollama.service
-		rm -r /usr/local/bin/ollama
-		rm -rf $defaultDir
-		rm -rf $ollamaModelsDirectory
-		rm -r /usr/share/ollama
-		rm -r /usr/bin/llaman 
+		rm -rf $serviceLocation/open-webui.service \
+			$serviceLocation/ollama.service \
+			/usr/local/bin/ollama \
+			$defaultDir \
+			$ollamaModelsDirectory \
+			/usr/share/ollama \
+			/usr/bin/llaman
+		echo ">> LLaMan | Ollama | Open-WebUI | OpendAI-Speech <<"
+		echo ">>                HAS BEEN DELETED!              <<"
 	 else
 		exit
 	fi
@@ -551,14 +661,14 @@ if [ -n "$1" ]; then
          -S | --stop) Control "stop" ;;
          -s | --start) Control "start" ;;
          -r | --restart) Control "restart" ;;
-         -t | --status) systemctl status ollama
-         	systemctl status open-webui ;;
+         -t | --status) Control "status" ;;
          -I | --install) InstallModel ;;
          -R | --remove) RemoveModel ;;
          -rg | --remove-gguf) RemoveGGUF ;;
          -D | --download) DownloadModel ;;
          -u | --update) Update ;;
          -cp | --change-port) ChangePort ;;
+         -cps | --change-port-speech) ChangePortSpeech ;;
          -v | --version) GetVersions ;;
          -vl | --view-logs) if ! HasSudo; then
 		exit

--- a/scripts/llaman
+++ b/scripts/llaman
@@ -367,24 +367,22 @@ UpdateWeb()
 
 	source $configFile
 	systemctl stop open-webui
-	if [[ -d $defaultDir/open-webui-backup ]]; then
-		rm -rf $defaultDir/open-webui-backup
-	fi
-	
-	mv $defaultDir/open-webui $defaultDir/open-webui-backup
+	cp -rfv $defaultDir/open-webui/backend/data $defaultDir/
+	rm -rf $defaultDir/open-webui
 	git clone https://github.com/open-webui/open-webui.git $defaultDir/
-	cp -RPp $defaultDir/open-webui/.env.example $defaultDir/open-webui/.env
 
 	cd $defaultDir/open-webui/
+	cp -RPp .env.example .env
 	npm i
 	npm run build
 	cd -
 
 	# Move data from previous install
-	cp -rfv $defaultDir/open-webui/open-webui-backup/backend/data $defaultDir/open-webui/backend/
+	cp -rfv $defaultDir/data $defaultDir/open-webui/backend/
 
 	sed -ri "s|exec uvicorn|python -m uvicorn|g" $defaultDir/open-webui/backend/start.sh
 	sed -i "/^WEBUI_SECRET_KEY=/ s/$/ | tee \/opt\/open-webui\/log\/open-webui.log/" $defaultDir/open-webui/backend/start.sh
+	sed -i 's/os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "True").lower() == "true"/os.environ.get("ENABLE_ADMIN_CHAT_ACCESS", "False").lower() == "false"/g' $defaultDir/open-webui/backend/open-webui/config.py
 	chown -Rf $defaultUser:$defaultUser $defaultDir
 	chmod -Rf 770 $defaultDir
 	sudo -u $defaultUser bash -c "
@@ -440,15 +438,10 @@ UpdateTTS(){
 	pyVersion="3.11"
 	systemctl stop opendai
 	source $defaultDir/miniconda3/bin/activate
-	if [[ -d $defaultDir/opendai-speech-backup ]]; then
-		rm -rf $defaultDir/opendai-speech-backup
-		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
-	elif [[ -d $defaultDir/opendai-speech ]]; then
-		mv -f $defaultDir/opendai-speech $defaultdir/opendai-speech-backup
-	fi
 	chown -Rf $defaultUser:$defaultUser $defaultDir
-	sudo -u $defaultUser bash -c "git clone https://github.com/matatonic/openedai-speech $defaultDir/opendai-speech
-		cp $defaultDir/opendai-speech-backup/start-tts.sh $defaultDir/opendai-speech/
+	sudo -u $defaultUser bash -c "cp $defaultDir/opendai-speech/start-tts.sh $defaultDir/
+		git clone https://github.com/matatonic/openedai-speech $defaultDir/opendai-speech
+		cp $defaultDir/start-tts.sh $defaultDir/opendai-speech/
 		source $defaultDir/miniconda3/etc/profile.d/conda.sh
 		conda init --all"
 	sudo -u $defaultUser bash -c "

--- a/scripts/start-tts.sh
+++ b/scripts/start-tts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source /opt/open-webui/config/llaman.conf
+
+[ -f speech.env ] && . speech.env
+
+defaultDir=/opt/open-webui
+condaSh=$defaultDir/miniconda3/etc/profile.d/conda.sh
+condaEnv=$defaultDir/config/conda/opendai
+
+source $condaSh
+conda activate $condaEnv
+./download_voices_tts-1.sh
+python speech.py -P $opendaiPort --xtts_device none $EXTRA_ARGS $@


### PR DESCRIPTION
## Changes
- Backup now completely backups /opt/open-webui and Ollama for easy import on another machine.
  - Meaning backups will now be rather large!

## Fixes
- Fixed language in setup.sh
- Fixed some langauge in llaman

## Additions
- Added OpendAI-Speech integration
  - _Default port is `8000`_
- Added `llaman -cps` (**C**hange **P**ort **S**peech)
  - _Presents a prompt to enter a new port for OpendAI-Speech_
- `sudo ./setup.sh` now has a `-I` option. Supply path to **I**mport a llaman.tar backup.
  - _example:_ `sudo ./setup.sh -I /path/to/llaman-backup.tar`